### PR TITLE
Program, Function Definition, Function Definition Params (and multi param)

### DIFF
--- a/exceptions/SyntaxException.java
+++ b/exceptions/SyntaxException.java
@@ -1,0 +1,7 @@
+package exceptions;
+
+public class SyntaxException extends RuntimeException {
+    public SyntaxException(String invalidToken, String filename, int lineNumber) {
+        super(String.format("Syntax Error\nInvalid token \"%s\"\n%s:%d\n", invalidToken, filename, lineNumber));
+    }
+}

--- a/nodes/FuncDefNode.java
+++ b/nodes/FuncDefNode.java
@@ -9,35 +9,32 @@ import java.util.ArrayList;
 
 public class FuncDefNode implements JottTree {
 
-    private ArrayList<JottTree> children = new ArrayList<>();
+    private IdNode funcName;
 
-    public FuncDefNode(ArrayList<JottTree> childList){
-        this.children.addAll(childList);
-    }
+    private ArrayList<FuncDefParamsNode> defParams;
+
+    private TypeNode functionReturn;
+
+    private BodyNode functionBody;
 
     @Override
     public String convertToJott() {
-        int i = 0;
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("def ");
-        stringBuilder.append(children.get(i).convertToJott());
-        i++;
+        stringBuilder.append(this.funcName.convertToJott());
         stringBuilder.append("[");
-        while (children.get(i) instanceof FuncDefParamsNode){
-            stringBuilder.append(children.get(i).convertToJott());
+        int i = 1;
+        for (FuncDefParamsNode defParam : this.defParams) {
+            stringBuilder.append(defParam.convertToJott());
             i++;
-            if (children.get(i) instanceof FuncDefParamsNode){
+            if (i <= this.defParams.size()){
                 stringBuilder.append(", ");
-            }
-            else {
-                break;
             }
         }
         stringBuilder.append("]:");
-        stringBuilder.append(children.get(i).convertToJott());
-        i++;
+        stringBuilder.append(functionReturn.convertToJott());
         stringBuilder.append(" {\n");
-        stringBuilder.append(children.get(i).convertToJott());
+        stringBuilder.append(functionBody.convertToJott());
         stringBuilder.append("}\n");
 
         return stringBuilder.toString();
@@ -67,18 +64,19 @@ public class FuncDefNode implements JottTree {
 
         // ArrayList.remove(0) essentially acts like pop.
         // Removes first element, shifts everything else up
-        ArrayList<JottTree> childNodeList = new ArrayList<>();
+        // ArrayList<JottTree> childNodeList = new ArrayList<>();
+        FuncDefNode funcDef = new FuncDefNode();
         Token currToken = tokens.remove(0);
 
         if (currToken.getToken().equals("def")) {
             // The token after def will be the function name
-            childNodeList.add(IdNode.parseIdNode(tokens));
+            funcDef.funcName = IdNode.parseIdNode(tokens);
             currToken = tokens.remove(0);
 
             // Next token after parsing the function id should be a left bracket
             if (currToken.getTokenType() == TokenType.L_BRACKET){
                 // Parse the function params present after the left bracket
-                childNodeList.addAll(FuncDefParamsNode.parseFuncDefParamsNode(tokens));
+                funcDef.defParams = FuncDefParamsNode.parseFuncDefParamsNode(tokens);
                 currToken = tokens.remove(0);
 
                 // Next token after parsing the function def params should be right bracket
@@ -88,13 +86,13 @@ public class FuncDefNode implements JottTree {
                     // Next token after the right bracket should be a colon
                     if (currToken.getTokenType() == TokenType.COLON){
                         // Parse the function return type
-                        childNodeList.add(TypeNode.parseTypeNode(tokens));
+                        funcDef.functionReturn = TypeNode.parseTypeNode(tokens);
                         currToken = tokens.remove(0);
 
                         // Next token after parsing function return type should be '{'
                         if (currToken.getTokenType() == TokenType.L_BRACE){
                             // Parse the body of this function
-                            childNodeList.add(BodyNode.parseBodyNode(tokens));
+                            funcDef.functionBody = BodyNode.parseBodyNode(tokens);
                             currToken = tokens.remove(0);
 
                             // Next token after parsing body should be '}'
@@ -122,7 +120,7 @@ public class FuncDefNode implements JottTree {
             FuncDefNode.throwParseEx(currToken);
         }
 
-        return new FuncDefNode(childNodeList);
+        return funcDef;
     }
 
     private static void throwParseEx(Token token){

--- a/nodes/FuncDefNode.java
+++ b/nodes/FuncDefNode.java
@@ -2,6 +2,7 @@ package nodes;
 
 import provided.JottTree;
 import provided.Token;
+import exceptions.*;
 
 import java.util.ArrayList;
 
@@ -42,7 +43,80 @@ public class FuncDefNode implements JottTree {
         return false;
     }
 
-    public static FuncDefNode parseNode(ArrayList<Token> tokens) {
-        return null;
+    public static FuncDefNode parseFuncDefNode(ArrayList<Token> tokens) {
+        ArrayList<JottTree> child_node_list = new ArrayList<>();
+
+        // ArrayList.remove(0) essentially acts like pop.
+        // Removes first element, shifts everything else up
+        Token currToken = tokens.remove(0);
+
+        if (currToken.getToken().equals("def")) {
+            // This IdNode will be the function name
+            // NOTE: I'm not responsible for IdNode, so this class doesn't exist yet (on this branch)
+            // It's my assumption that it'll function like the other nodes
+            // REMOVE THIS NOTE FOR MERGE
+            child_node_list.add(IdNode.parseNode(tokens));
+            currToken = tokens.remove(0);
+
+            // Next token after parsing the function id should be '['
+            if (currToken.getToken().equals("[")){
+                // Parse the function params present after the '['
+                child_node_list.addAll(FuncParamsNode.parseNode(tokens));
+                currToken = tokens.remove(0);
+
+                // Next token after parsing the function params should be ']'
+                if (currToken.getToken().equals("]")) {
+                    currToken = tokens.remove(0);
+
+                    // Next token after ']' should be ':'
+                    if (currToken.getToken().equals(":")){
+                        // Parse the function return type
+                        // NOTE: See note on IdNode above, same applies to TypeNode
+                        // REMOVE THIS NOTE FOR MERGE
+                        child_node_list.add(TypeNode.parseNode(tokens));
+                        currToken = tokens.remove(0);
+
+                        // Next token after parsing function return type should be '{'
+                        if (currToken.getToken().equals("{")){
+                            // Parse the body of this function
+                            // NOTE: See note on IdNode above, same applies to BodyNode
+                            // REMOVE THIS NOTE FOR MERGE
+                            child_node_list.add(BodyNode.parseNode(tokens));
+                            currToken = tokens.remove(0);
+
+                            // Next token after parsing body should be '}'
+                            if (!currToken.getToken().equals("}")) {
+                                FuncDefNode.throwParseEx(currToken);
+                            }
+                        }
+                        else {
+                            FuncDefNode.throwParseEx(currToken);
+                        }
+                    }
+                    else {
+                        FuncDefNode.throwParseEx(currToken);
+                    }
+                }
+                else {
+                    FuncDefNode.throwParseEx(currToken);
+                }
+            }
+            else {
+                FuncDefNode.throwParseEx(currToken);
+            }
+        }
+        else {
+            FuncDefNode.throwParseEx(currToken);
+        }
+
+        return new FuncDefNode(child_node_list);
+    }
+
+    private static void throwParseEx(Token token){
+        throw new SyntaxException(
+                token.getToken(),
+                token.getFilename(),
+                token.getLineNum()
+        );
     }
 }

--- a/nodes/FuncDefNode.java
+++ b/nodes/FuncDefNode.java
@@ -21,7 +21,30 @@ public class FuncDefNode implements JottTree {
 
     @Override
     public String convertToJott() {
-        return null;
+        int i = 0;
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("def ");
+        stringBuilder.append(children.get(i).convertToJott());
+        i++;
+        stringBuilder.append("[");
+        while (children.get(i) instanceof FuncDefParamsNode){
+            stringBuilder.append(children.get(i).convertToJott());
+            i++;
+            if (children.get(i) instanceof FuncDefParamsNode){
+                stringBuilder.append(", ");
+            }
+            else {
+                break;
+            }
+        }
+        stringBuilder.append("]:");
+        stringBuilder.append(children.get(i).convertToJott());
+        i++;
+        stringBuilder.append(" {\n");
+        stringBuilder.append(children.get(i).convertToJott());
+        stringBuilder.append("}\n");
+
+        return stringBuilder.toString();
     }
 
     @Override

--- a/nodes/FuncDefNode.java
+++ b/nodes/FuncDefNode.java
@@ -12,11 +12,7 @@ public class FuncDefNode implements JottTree {
     private ArrayList<JottTree> children = new ArrayList<>();
 
     public FuncDefNode(ArrayList<JottTree> childList){
-        try {
-            this.children.addAll(childList);
-        } catch (NullPointerException ignored) {
-            ;
-        }
+        this.children.addAll(childList);
     }
 
     @Override

--- a/nodes/FuncDefNode.java
+++ b/nodes/FuncDefNode.java
@@ -13,7 +13,7 @@ public class FuncDefNode implements JottTree {
 
     private ArrayList<FuncDefParamsNode> defParams;
 
-    private TypeNode functionReturn;
+    private FuncReturnNode functionReturn;
 
     private BodyNode functionBody;
 
@@ -86,7 +86,7 @@ public class FuncDefNode implements JottTree {
                     // Next token after the right bracket should be a colon
                     if (currToken.getTokenType() == TokenType.COLON){
                         // Parse the function return type
-                        funcDef.functionReturn = TypeNode.parseTypeNode(tokens);
+                        funcDef.functionReturn = FuncReturnNode.parseTypeNode(tokens);
                         currToken = tokens.remove(0);
 
                         // Next token after parsing function return type should be '{'

--- a/nodes/FuncDefNode.java
+++ b/nodes/FuncDefNode.java
@@ -3,6 +3,7 @@ package nodes;
 import provided.JottTree;
 import provided.Token;
 import exceptions.*;
+import provided.TokenType;
 
 import java.util.ArrayList;
 
@@ -59,17 +60,17 @@ public class FuncDefNode implements JottTree {
             currToken = tokens.remove(0);
 
             // Next token after parsing the function id should be '['
-            if (currToken.getToken().equals("[")){
+            if (currToken.getTokenType() == TokenType.L_BRACKET){
                 // Parse the function params present after the '['
-                child_node_list.addAll(FuncParamsNode.parseNode(tokens));
+                child_node_list.addAll(FuncDefParamsNode.parseNode(tokens));
                 currToken = tokens.remove(0);
 
-                // Next token after parsing the function params should be ']'
-                if (currToken.getToken().equals("]")) {
+                // Next token after parsing the function def params should be ']'
+                if (currToken.getTokenType() == TokenType.R_BRACKET) {
                     currToken = tokens.remove(0);
 
                     // Next token after ']' should be ':'
-                    if (currToken.getToken().equals(":")){
+                    if (currToken.getTokenType() == TokenType.COLON){
                         // Parse the function return type
                         // NOTE: See note on IdNode above, same applies to TypeNode
                         // REMOVE THIS NOTE FOR MERGE
@@ -77,7 +78,7 @@ public class FuncDefNode implements JottTree {
                         currToken = tokens.remove(0);
 
                         // Next token after parsing function return type should be '{'
-                        if (currToken.getToken().equals("{")){
+                        if (currToken.getTokenType() == TokenType.L_BRACE){
                             // Parse the body of this function
                             // NOTE: See note on IdNode above, same applies to BodyNode
                             // REMOVE THIS NOTE FOR MERGE
@@ -85,7 +86,7 @@ public class FuncDefNode implements JottTree {
                             currToken = tokens.remove(0);
 
                             // Next token after parsing body should be '}'
-                            if (!currToken.getToken().equals("}")) {
+                            if (currToken.getTokenType() != TokenType.R_BRACE) {
                                 FuncDefNode.throwParseEx(currToken);
                             }
                         }

--- a/nodes/FuncDefNode.java
+++ b/nodes/FuncDefNode.java
@@ -3,14 +3,13 @@ package nodes;
 import provided.JottTree;
 import provided.Token;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 
-public class ProgramNode implements JottTree {
+public class FuncDefNode implements JottTree {
 
     private ArrayList<JottTree> children;
 
-    public ProgramNode(ArrayList<JottTree> childList){
+    public FuncDefNode(ArrayList<JottTree> childList){
         try {
             children.addAll(childList);
         } catch (NullPointerException ignored) {
@@ -43,11 +42,7 @@ public class ProgramNode implements JottTree {
         return false;
     }
 
-    public static ProgramNode parseNode(ArrayList<Token> tokens){
-        ArrayList<JottTree> funcDefNodes = new ArrayList<>();
-        while (!tokens.isEmpty()){
-            funcDefNodes.add(FuncDefNode.parseNode(tokens));
-        }
-        return new ProgramNode(funcDefNodes);
+    public static FuncDefNode parseNode(ArrayList<Token> tokens) {
+        return null;
     }
 }

--- a/nodes/FuncDefNode.java
+++ b/nodes/FuncDefNode.java
@@ -45,44 +45,37 @@ public class FuncDefNode implements JottTree {
     }
 
     public static FuncDefNode parseFuncDefNode(ArrayList<Token> tokens) {
-        ArrayList<JottTree> child_node_list = new ArrayList<>();
 
         // ArrayList.remove(0) essentially acts like pop.
         // Removes first element, shifts everything else up
+        ArrayList<JottTree> childNodeList = new ArrayList<>();
         Token currToken = tokens.remove(0);
 
         if (currToken.getToken().equals("def")) {
-            // This IdNode will be the function name
-            // NOTE: I'm not responsible for IdNode, so this class doesn't exist yet (on this branch)
-            // It's my assumption that it'll function like the other nodes
-            // REMOVE THIS NOTE FOR MERGE
-            child_node_list.add(IdNode.parseNode(tokens));
+            // The token after def will be the function name
+            childNodeList.add(IdNode.parseIdNode(tokens));
             currToken = tokens.remove(0);
 
-            // Next token after parsing the function id should be '['
+            // Next token after parsing the function id should be a left bracket
             if (currToken.getTokenType() == TokenType.L_BRACKET){
-                // Parse the function params present after the '['
-                child_node_list.addAll(FuncDefParamsNode.parseNode(tokens));
+                // Parse the function params present after the left bracket
+                childNodeList.addAll(FuncDefParamsNode.parseFuncDefParamsNode(tokens));
                 currToken = tokens.remove(0);
 
-                // Next token after parsing the function def params should be ']'
+                // Next token after parsing the function def params should be right bracket
                 if (currToken.getTokenType() == TokenType.R_BRACKET) {
                     currToken = tokens.remove(0);
 
-                    // Next token after ']' should be ':'
+                    // Next token after the right bracket should be a colon
                     if (currToken.getTokenType() == TokenType.COLON){
                         // Parse the function return type
-                        // NOTE: See note on IdNode above, same applies to TypeNode
-                        // REMOVE THIS NOTE FOR MERGE
-                        child_node_list.add(TypeNode.parseNode(tokens));
+                        childNodeList.add(TypeNode.parseTypeNode(tokens));
                         currToken = tokens.remove(0);
 
                         // Next token after parsing function return type should be '{'
                         if (currToken.getTokenType() == TokenType.L_BRACE){
                             // Parse the body of this function
-                            // NOTE: See note on IdNode above, same applies to BodyNode
-                            // REMOVE THIS NOTE FOR MERGE
-                            child_node_list.add(BodyNode.parseNode(tokens));
+                            childNodeList.add(BodyNode.parseBodyNode(tokens));
                             currToken = tokens.remove(0);
 
                             // Next token after parsing body should be '}'
@@ -110,7 +103,7 @@ public class FuncDefNode implements JottTree {
             FuncDefNode.throwParseEx(currToken);
         }
 
-        return new FuncDefNode(child_node_list);
+        return new FuncDefNode(childNodeList);
     }
 
     private static void throwParseEx(Token token){

--- a/nodes/FuncDefNode.java
+++ b/nodes/FuncDefNode.java
@@ -9,11 +9,11 @@ import java.util.ArrayList;
 
 public class FuncDefNode implements JottTree {
 
-    private ArrayList<JottTree> children;
+    private ArrayList<JottTree> children = new ArrayList<>();
 
     public FuncDefNode(ArrayList<JottTree> childList){
         try {
-            children.addAll(childList);
+            this.children.addAll(childList);
         } catch (NullPointerException ignored) {
             ;
         }

--- a/nodes/FuncDefNode.java
+++ b/nodes/FuncDefNode.java
@@ -5,7 +5,9 @@ import provided.Token;
 import exceptions.*;
 import provided.TokenType;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 public class FuncDefNode implements JottTree {
 
@@ -13,7 +15,9 @@ public class FuncDefNode implements JottTree {
 
     private ArrayList<FuncDefParamsNode> defParams;
 
-    private FuncReturnNode functionReturn;
+    private Token functionReturn;
+    private static final ArrayList<String> returnTypes =
+            new ArrayList<>(Arrays.asList("DOUBLE", "INTEGER", "STRING", "BOOLEAN", "VOID"));
 
     private BodyNode functionBody;
 
@@ -30,7 +34,7 @@ public class FuncDefNode implements JottTree {
             }
         }
         stringBuilder.append("]:");
-        stringBuilder.append(functionReturn.convertToJott());
+        stringBuilder.append(functionReturn.getToken());
         stringBuilder.append(" {\n");
         stringBuilder.append(functionBody.convertToJott());
         stringBuilder.append("}\n");
@@ -84,7 +88,13 @@ public class FuncDefNode implements JottTree {
                     // Next token after the right bracket should be a colon
                     if (currToken.getTokenType() == TokenType.COLON){
                         // Parse the function return type
-                        funcDef.functionReturn = FuncReturnNode.parseTypeNode(tokens);
+                        currToken = tokens.remove(0);
+                        if (returnTypes.contains(currToken.getToken().toUpperCase())) {
+                            funcDef.functionReturn = currToken;
+                        }
+                        else {
+                            FuncDefNode.throwParseEx(currToken);
+                        }
                         currToken = tokens.remove(0);
 
                         // Next token after parsing function return type should be '{'

--- a/nodes/FuncDefNode.java
+++ b/nodes/FuncDefNode.java
@@ -23,11 +23,9 @@ public class FuncDefNode implements JottTree {
         stringBuilder.append("def ");
         stringBuilder.append(this.funcName.convertToJott());
         stringBuilder.append("[");
-        int i = 1;
-        for (FuncDefParamsNode defParam : this.defParams) {
-            stringBuilder.append(defParam.convertToJott());
-            i++;
-            if (i <= this.defParams.size()){
+        for (int i = 0; i < this.defParams.size(); i++){
+            stringBuilder.append(this.defParams.get(i).convertToJott());
+            if (i+1 <= this.defParams.size()){
                 stringBuilder.append(", ");
             }
         }

--- a/nodes/FuncDefParamsNode.java
+++ b/nodes/FuncDefParamsNode.java
@@ -1,0 +1,85 @@
+package nodes;
+
+import exceptions.SyntaxException;
+import provided.JottTree;
+import provided.Token;
+import provided.TokenType;
+
+import java.util.ArrayList;
+
+public class FuncDefParamsNode implements JottTree {
+
+    private ArrayList<JottTree> children = new ArrayList<>();
+
+    public FuncDefParamsNode(ArrayList<JottTree> childList){
+        try {
+            this.children.addAll(childList);
+        } catch (NullPointerException ignored) {
+            ;
+        }
+    }
+
+    @Override
+    public String convertToJott() {
+        return null;
+    }
+
+    @Override
+    public String convertToJava(String className) {
+        return null;
+    }
+
+    @Override
+    public String convertToC() {
+        return null;
+    }
+
+    @Override
+    public String convertToPython() {
+        return null;
+    }
+
+    @Override
+    public boolean validateTree() {
+        return false;
+    }
+
+    public static ArrayList<FuncDefParamsNode> parseFuncDefParamsNode(ArrayList<Token> tokens) {
+        ArrayList<FuncDefParamsNode> defParamsNodes = new ArrayList<>();
+        ArrayList<JottTree> childNodeList = new ArrayList<>();
+
+        Token currToken = tokens.get(0);
+        if (currToken.getTokenType() != TokenType.ID_KEYWORD){
+            // No params for the function def. FuncDefNode will handle this token,
+            // which should be a right bracket
+            return defParamsNodes;
+        }
+        while (true) {
+            // Parse the id
+            childNodeList.add(IdNode.parseIdNode(tokens));
+            currToken = tokens.remove(0);
+
+            // After id is parsed, next token should be a colon
+            if (currToken.getTokenType() == TokenType.COLON) {
+                childNodeList.add(TypeNode.parseTypeNode(tokens));
+                defParamsNodes.add(new FuncDefParamsNode(childNodeList));
+                currToken = tokens.get(0);
+
+                // If the current token isn't a comma, then this is the end of the param list
+                if (currToken.getTokenType() != TokenType.COMMA) {
+                    return defParamsNodes;
+                }
+
+                // If it is a comma, remove it and loop to parse the next param
+                tokens.remove(0);
+
+            } else {
+                throw new SyntaxException(
+                        currToken.getToken(),
+                        currToken.getFilename(),
+                        currToken.getLineNum()
+                );
+            }
+        }
+    }
+}

--- a/nodes/FuncDefParamsNode.java
+++ b/nodes/FuncDefParamsNode.java
@@ -21,7 +21,7 @@ public class FuncDefParamsNode implements JottTree {
 
     @Override
     public String convertToJott() {
-        return null;
+        return children.get(0).convertToJott() + ":" + children.get(1).convertToJott();
     }
 
     @Override

--- a/nodes/FuncDefParamsNode.java
+++ b/nodes/FuncDefParamsNode.java
@@ -12,11 +12,7 @@ public class FuncDefParamsNode implements JottTree {
     private ArrayList<JottTree> children = new ArrayList<>();
 
     public FuncDefParamsNode(ArrayList<JottTree> childList){
-        try {
-            this.children.addAll(childList);
-        } catch (NullPointerException ignored) {
-            ;
-        }
+        this.children.addAll(childList);
     }
 
     @Override

--- a/nodes/FuncDefParamsNode.java
+++ b/nodes/FuncDefParamsNode.java
@@ -9,15 +9,13 @@ import java.util.ArrayList;
 
 public class FuncDefParamsNode implements JottTree {
 
-    private ArrayList<JottTree> children = new ArrayList<>();
+    private IdNode defParamName;
 
-    public FuncDefParamsNode(ArrayList<JottTree> childList){
-        this.children.addAll(childList);
-    }
+    private TypeNode defParamType;
 
     @Override
     public String convertToJott() {
-        return children.get(0).convertToJott() + ":" + children.get(1).convertToJott();
+        return this.defParamName.convertToJott() + ":" + this.defParamType.convertToJott();
     }
 
     @Override
@@ -42,7 +40,6 @@ public class FuncDefParamsNode implements JottTree {
 
     public static ArrayList<FuncDefParamsNode> parseFuncDefParamsNode(ArrayList<Token> tokens) {
         ArrayList<FuncDefParamsNode> defParamsNodes = new ArrayList<>();
-        ArrayList<JottTree> childNodeList = new ArrayList<>();
 
         Token currToken = tokens.get(0);
         if (currToken.getTokenType() != TokenType.ID_KEYWORD){
@@ -51,14 +48,15 @@ public class FuncDefParamsNode implements JottTree {
             return defParamsNodes;
         }
         while (true) {
+            FuncDefParamsNode funcDefParam = new FuncDefParamsNode();
             // Parse the id
-            childNodeList.add(IdNode.parseIdNode(tokens));
+            funcDefParam.defParamName = IdNode.parseIdNode(tokens);
             currToken = tokens.remove(0);
 
             // After id is parsed, next token should be a colon
             if (currToken.getTokenType() == TokenType.COLON) {
-                childNodeList.add(TypeNode.parseTypeNode(tokens));
-                defParamsNodes.add(new FuncDefParamsNode(childNodeList));
+                funcDefParam.defParamType = TypeNode.parseTypeNode(tokens);
+                defParamsNodes.add(funcDefParam);
                 currToken = tokens.get(0);
 
                 // If the current token isn't a comma, then this is the end of the param list

--- a/nodes/ProgramNode.java
+++ b/nodes/ProgramNode.java
@@ -11,11 +11,7 @@ public class ProgramNode implements JottTree {
     private ArrayList<JottTree> children = new ArrayList<>();
 
     public ProgramNode(ArrayList<JottTree> childList){
-        try {
-            this.children.addAll(childList);
-        } catch (NullPointerException ignored) {
-            ;
-        }
+        this.children.addAll(childList);
     }
 
     @Override

--- a/nodes/ProgramNode.java
+++ b/nodes/ProgramNode.java
@@ -20,7 +20,11 @@ public class ProgramNode implements JottTree {
 
     @Override
     public String convertToJott() {
-        return null;
+        StringBuilder stringBuilder = new StringBuilder();
+        for (JottTree node: children){
+            stringBuilder.append(node.convertToJott());
+        }
+        return stringBuilder.toString();
     }
 
     @Override

--- a/nodes/ProgramNode.java
+++ b/nodes/ProgramNode.java
@@ -8,11 +8,11 @@ import java.util.ArrayList;
 
 public class ProgramNode implements JottTree {
 
-    private ArrayList<JottTree> children;
+    private ArrayList<JottTree> children = new ArrayList<>();
 
     public ProgramNode(ArrayList<JottTree> childList){
         try {
-            children.addAll(childList);
+            this.children.addAll(childList);
         } catch (NullPointerException ignored) {
             ;
         }

--- a/nodes/ProgramNode.java
+++ b/nodes/ProgramNode.java
@@ -43,10 +43,10 @@ public class ProgramNode implements JottTree {
         return false;
     }
 
-    public static ProgramNode parseNode(ArrayList<Token> tokens){
+    public static ProgramNode parseProgramNode(ArrayList<Token> tokens){
         ArrayList<JottTree> funcDefNodes = new ArrayList<>();
         while (!tokens.isEmpty()){
-            funcDefNodes.add(FuncDefNode.parseNode(tokens));
+            funcDefNodes.add(FuncDefNode.parseFuncDefNode(tokens));
         }
         return new ProgramNode(funcDefNodes);
     }

--- a/nodes/ProgramNode.java
+++ b/nodes/ProgramNode.java
@@ -8,17 +8,17 @@ import java.util.ArrayList;
 
 public class ProgramNode implements JottTree {
 
-    private ArrayList<JottTree> children = new ArrayList<>();
+    private ArrayList<FuncDefNode> funcDefs = new ArrayList<>();
 
-    public ProgramNode(ArrayList<JottTree> childList){
-        this.children.addAll(childList);
+    public ProgramNode(ArrayList<FuncDefNode> childList){
+        this.funcDefs.addAll(childList);
     }
 
     @Override
     public String convertToJott() {
         StringBuilder stringBuilder = new StringBuilder();
-        for (JottTree node: children){
-            stringBuilder.append(node.convertToJott());
+        for (FuncDefNode funcDef: funcDefs){
+            stringBuilder.append(funcDef.convertToJott());
         }
         return stringBuilder.toString();
     }
@@ -44,7 +44,7 @@ public class ProgramNode implements JottTree {
     }
 
     public static ProgramNode parseProgramNode(ArrayList<Token> tokens){
-        ArrayList<JottTree> funcDefNodes = new ArrayList<>();
+        ArrayList<FuncDefNode> funcDefNodes = new ArrayList<>();
         while (!tokens.isEmpty()){
             funcDefNodes.add(FuncDefNode.parseFuncDefNode(tokens));
         }

--- a/nodes/ProgramNode.java
+++ b/nodes/ProgramNode.java
@@ -1,0 +1,30 @@
+package nodes;
+
+import provided.JottTree;
+
+public class ProgramNode implements JottTree {
+    @Override
+    public String convertToJott() {
+        return null;
+    }
+
+    @Override
+    public String convertToJava(String className) {
+        return null;
+    }
+
+    @Override
+    public String convertToC() {
+        return null;
+    }
+
+    @Override
+    public String convertToPython() {
+        return null;
+    }
+
+    @Override
+    public boolean validateTree() {
+        return false;
+    }
+}

--- a/provided/JottParser.java
+++ b/provided/JottParser.java
@@ -1,4 +1,5 @@
 package provided;
+import nodes.*;
 
 /**
  * This class is responsible for paring Jott Tokens
@@ -18,6 +19,9 @@ public class JottParser {
      *         or null upon an error in parsing.
      */
     public static JottTree parse(ArrayList<Token> tokens){
-		return null;
+        for (int i = 0; i < tokens.size(); i++){
+
+        }
+        return null;
     }
 }

--- a/provided/JottParser.java
+++ b/provided/JottParser.java
@@ -19,9 +19,6 @@ public class JottParser {
      *         or null upon an error in parsing.
      */
     public static JottTree parse(ArrayList<Token> tokens){
-        /*for (int i = 0; i < tokens.size(); i++){
-
-        }*/
-        return ProgramNode.parseNode(tokens);
+        return ProgramNode.parseProgramNode(tokens);
     }
 }

--- a/provided/JottParser.java
+++ b/provided/JottParser.java
@@ -19,9 +19,9 @@ public class JottParser {
      *         or null upon an error in parsing.
      */
     public static JottTree parse(ArrayList<Token> tokens){
-        for (int i = 0; i < tokens.size(); i++){
+        /*for (int i = 0; i < tokens.size(); i++){
 
-        }
-        return null;
+        }*/
+        return ProgramNode.parseNode(tokens);
     }
 }


### PR DESCRIPTION
NOTE: My branch takes some commits from `parser-uzo` since I needed the Syntax error class.
NOTE 2: This is untested, so _please look at this carefully and lmk if you have questions on my implementation_. Afaik we're not gonna be able to test anybody's stuff til everybody's stuff works, as my changes call parsing functions from nodes that don't exist on main yet.

Completed the implementation of the `parseNode` and `convertToJott` functions for `ProgramNode`,  `FuncDefNode`, and `FuncDefParamsNode`. The ability to parse multiple function definition parameters is built into the parsing function of `FuncDefParamsNode`, so there is no need for an extra class for the grammar rule "func_def_params_t".